### PR TITLE
Create SecurityHubFindingsToSlack_cloudwatch_rule.txt

### DIFF
--- a/SecurityHubFindingsToSlack_cloudwatch_rule.txt
+++ b/SecurityHubFindingsToSlack_cloudwatch_rule.txt
@@ -1,0 +1,15 @@
+{
+  "source": [
+    "aws.securityhub"
+  ],
+  "detail": {
+    "findings": {
+      "ProductFields": {
+        "aws/securityhub/SeverityLabel": [
+          "HIGH",
+          "CRITICAL"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
added a cloudwatch rule example to send only HIGH and CRITICAL events to Slack

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
