### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/SecurityHubFindingsToSlack.json
+++ b/SecurityHubFindingsToSlack.json
@@ -205,7 +205,7 @@
             "webHookUrl" : { "Ref": "IncomingWebHookURL" }
             }
         },
-        "Runtime": "nodejs8.10",
+        "Runtime": "nodejs10.x",
         "MemorySize" : 128,
                 "Timeout": 10,
         "Description" : "Lambda to push SecurityHub findings to Slack",


### PR DESCRIPTION
CloudFormation templates in aws-securityhub-to-slack have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.