### PR TITLE
correct time formating + cleaner findings description

### DIFF
--- a/SecurityHubFindingsToSlack.json
+++ b/SecurityHubFindingsToSlack.json
@@ -71,7 +71,7 @@
                 "Name" : "SecurityHubFindingsToSlack",
                 "Description": "CloudWatchEvents Rule to enable SecurityHub Findings in Slack ",
                 "State": "ENABLED",
-                "EventPattern" : { 
+                "EventPattern" : {
                     "source": ["aws.securityhub"],
                     "resources":  [{ "Fn::Join" : [ ":", [ "arn", "aws", "securityhub", { "Ref" : "AWS::Region" }, { "Ref" : "AWS::AccountId" }, { "Fn::Join" : [ "/", [ "action", "custom", "SendToSlack"] ] }]
             ]}]},
@@ -141,7 +141,7 @@
                             "const consoleUrl = `https://console.aws.amazon.com/securityhub`;\n",
                             "const finding = message.detail.findings[0].Types[0];\n",
                             "const findingDescription = message.detail.findings[0].Description;\n",
-                            "const findingTime = message.detail.findings[0].updatedAt;\n",
+                            "const findingTime = message.detail.findings[0].UpdatedAt;\n",
                             "const findingTimeEpoch = Math.floor(new Date(findingTime) / 1000);\n",
                             "const account =  message.detail.findings[0].AwsAccountId;\n",
                             "const region =  message.detail.findings[0].Resources[0].Region;\n",
@@ -159,7 +159,7 @@
                             "\n",
                             "const attachment = [{\n",
                             "\"fallback\": finding + ` - ${consoleUrl}/home?region=` + `${region}#/findings?search=id%3D${messageId}`,\n",
-                            "\"pretext\": `*AWS SecurityHub finding in ${region} for Acct: ${account}*`,\n",
+                            "\"pretext\": `*AWS Security Hub finding for account: ${account}*`,\n",
                             "\"title\": `${finding}`,\n",
                             "\"title_link\": `${consoleUrl}/home?region=${region}#/research`,\n",
                             "\n",


### PR DESCRIPTION
Time for "Last Seen" is not formatted correctly because of casing issue for findingTime const. Also region for a finding is showing twice in Slack.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
