### PR TITLE
'CREATE_FAILED' on 'SecurityHub_to_AWSChatBot.yml' during creations after the 2nd time on another regions

### DIFF
--- a/SecurityHub_to_AWSChatBot.yml
+++ b/SecurityHub_to_AWSChatBot.yml
@@ -22,16 +22,23 @@ Parameters:
     AllowedPattern: ^[a-zA-Z0-9_]*$
     ConstraintDescription: |
       Malformed Input Parameter: Environment must contain only upper and numbers. Length should be a minimum of 9 characters and a maximum of 15 characters.
-      
- 
+
   # CustomActionName:
   #   Description: Name of the Custom Action in SecurityHub
   #   Type: String
   #   AllowedPattern: ^[a-zA-Z0-9_]*$ 
   #   Default: Send_To_Slack
   #   #Default: 'Send To !Sub "${ChatApplication}"'
- 
- 
+
+  configureSlackChannel:
+    Type: String
+    AllowedValues: [ true, false ]
+    Default: true
+
+Conditions:
+    configureSlackChannelConfig: !Equals [ !Ref configureSlackChannel, true ]
+    noConfigureSlackChannelConfig: !Equals [ !Ref configureSlackChannel, false ]
+
 #==================================================
 # Resources
 #==================================================
@@ -123,6 +130,13 @@ Resources:
             Resource: '*'
         Topics:
           - !Ref SNSTopicAWSChatBot
+  AWSChatBotSubscription:
+    Type: AWS::SNS::Subscription
+    Condition: noConfigureSlackChannelConfig
+    Properties: 
+      Endpoint: https://global.sns-api.chatbot.amazonaws.com
+      Protocol: HTTPS
+      TopicArn: !Ref SNSTopicAWSChatBot
   #======================================================
   # CloudWatch Event Rule
   #======================================================        
@@ -158,6 +172,7 @@ Resources:
               - "sts:AssumeRole"
   SlackChannelConfig:
     Type: AWS::Chatbot::SlackChannelConfiguration
+    Condition: configureSlackChannelConfig
     Properties: 
       ConfigurationName: securityhubnotification
       IamRoleArn: !GetAtt ChatBotManageIAMRole.Arn
@@ -165,4 +180,4 @@ Resources:
       SlackChannelId: !Ref SlackChannelID
       SlackWorkspaceId: !Ref SlackWorkSpaceID
       SnsTopicArns: 
-        - !Ref  SNSTopicAWSChatBot                          
+        - !Ref  SNSTopicAWSChatBot


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

CREATE_FAILED have been observed with Events like shown below

> 2020-07-02 13:56:12 UTC+0900	SecurityHubToAWSChatBot	ROLLBACK_IN_PROGRESS	The following resource(s) failed to create: [EventRuleCustomAction, SlackChannelConfig, LambdaIAMPolicy]. . Rollback requested by user.
> 2020-07-02 13:56:11 UTC+0900	LambdaIAMPolicy	CREATE_FAILED	Resource creation cancelled
> 2020-07-02 13:56:11 UTC+0900	EventRuleCustomAction	CREATE_FAILED	Resource creation cancelled
> 2020-07-02 13:56:11 UTC+0900	SlackChannelConfig	CREATE_FAILED	Invalid request provided: The chat configuration with the name securityhubnotification already exists. Retry with a unique configuration name. (Service: AWSChatbot; Status Code: 400; Error Code: InvalidParameterException; Request ID: f6aXXXXX-XXXX-XXXX-XXXXXXXXXXXXXXXXX; Proxy: null)

It does not happen when a region was the first one(assuming us-east-1 here) on a AWS accunt.
Thereafter failure then happens on further creations on another regions such as us-east-2 or whatever else.
In my understanding, since AWS Chatbot is a global service, 'SlackChannelConfig' would also not be dedicated for a particular region neither cannot be defined idempotently on CloudFormation. It simply disallows duplication. Therefore in order to deploy among multiple regions, an option should be present NOT to attempt to duplicate 'SlackChannelConfig' needlessly.

With this pr, user would unfortunately have to work additional steps as follows(if he wanted create-stack after the 2nd regions):
1. provide explicit false as a parameter of Cloudformation stack, to supress 'SlackChannelConfig'
1. After CREATE_COMPLETE, Go to AWS Chatbot console > Configured clients > Slack workspace: YOURWORKSPACE > securityhubnotification
1. On `securityhubnotification`, press Edit button on top-right
1. Navigate to bottom of the page, press 'Add another Region', Choose appropreate Region and SNS Topic which supposed to appear

Then finally user would be able to obtain cross-region findings automatically on his slack channel.
I know this is not very smart but this is the best I could come up with for now.
If there was more reasonable way, I would like it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
