### PR TITLE
AddCustomActionSHResource1	DELETE_FAILED at stack deletion of 'SecurityHub_to_AWSChatBot.yml'

### DIFF
--- a/SecurityHub_to_AWSChatBot.yml
+++ b/SecurityHub_to_AWSChatBot.yml
@@ -91,11 +91,13 @@ Resources:
           def lambda_handler(event, context):
             securityhub = boto3.client('securityhub')
             responseData = {}
+            responceStatus = cfnresponse.SUCCESS
             if event['RequestType'] == 'Create':
               try:
                 responseData['Data'] = securityhub.create_action_target(Name="Send_To_Slack",Description='Send Messages to ChatApplication via AWS ChatBot',Id='SendToSlack')
               except Exception as e:
                 responseData['Data'] = str(e)
+                responceStatus = cfnresponse.FAILED
 
             if event['RequestType'] == 'Delete':
               try:
@@ -107,9 +109,14 @@ Resources:
                   ':action/custom/SendToSlack'
                 ] )
                 responseData['Data'] = securityhub.delete_action_target(ActionTargetArn=arnDeleteTo)
+              except securityhub.exceptions.ResourceNotFoundException as rnfe:
+                responseData['Data'] = str(rnfe)
               except Exception as e:
                 responseData['Data'] = str(e)
-            cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, "CustomResourcePhysicalID") 
+                responceStatus = cfnresponse.FAILED
+
+            cfnresponse.send(event, context, responceStatus, responseData, "CustomResourcePhysicalID") 
+
       MemorySize: 128
       Timeout: 10
       Role: !GetAtt LambdaIAMRole.Arn  

--- a/SecurityHub_to_AWSChatBot.yml
+++ b/SecurityHub_to_AWSChatBot.yml
@@ -91,13 +91,13 @@ Resources:
           def lambda_handler(event, context):
             securityhub = boto3.client('securityhub')
             responseData = {}
-            responceStatus = cfnresponse.SUCCESS
+            responseStatus = cfnresponse.SUCCESS
             if event['RequestType'] == 'Create':
               try:
                 responseData['Data'] = securityhub.create_action_target(Name="Send_To_Slack",Description='Send Messages to ChatApplication via AWS ChatBot',Id='SendToSlack')
               except Exception as e:
                 responseData['Data'] = str(e)
-                responceStatus = cfnresponse.FAILED
+                responseStatus = cfnresponse.FAILED
 
             if event['RequestType'] == 'Delete':
               try:
@@ -113,9 +113,9 @@ Resources:
                 responseData['Data'] = str(rnfe)
               except Exception as e:
                 responseData['Data'] = str(e)
-                responceStatus = cfnresponse.FAILED
+                responseStatus = cfnresponse.FAILED
 
-            cfnresponse.send(event, context, responceStatus, responseData, "CustomResourcePhysicalID") 
+            cfnresponse.send(event, context, responseStatus, responseData, "CustomResourcePhysicalID")
 
       MemorySize: 128
       Timeout: 10

--- a/SecurityHub_to_AWSChatBot.yml
+++ b/SecurityHub_to_AWSChatBot.yml
@@ -68,6 +68,7 @@ Resources:
           - Effect: Allow
             Action:
               - 'securityhub:CreateActionTarget'
+              - 'securityhub:DeleteActionTarget'
             Resource: '*'
       Roles: 
         - !Ref LambdaIAMRole
@@ -85,12 +86,29 @@ Resources:
       Code:
         ZipFile: |
           import boto3
+          import os
           import cfnresponse
           def lambda_handler(event, context):
             securityhub = boto3.client('securityhub')
-            response = securityhub.create_action_target(Name="Send_To_Slack",Description='Send Messages to ChatApplication via AWS ChatBot',Id='SendToSlack')
             responseData = {}
-            responseData['Data'] = response
+            if event['RequestType'] == 'Create':
+              try:
+                responseData['Data'] = securityhub.create_action_target(Name="Send_To_Slack",Description='Send Messages to ChatApplication via AWS ChatBot',Id='SendToSlack')
+              except Exception as e:
+                responseData['Data'] = str(e)
+
+            if event['RequestType'] == 'Delete':
+              try:
+                arnDeleteTo = ''.join( [
+                  'arn:aws:securityhub:',
+                  os.environ.get('AWS_REGION'),
+                  ':',
+                  boto3.client('sts').get_caller_identity().get('Account'),
+                  ':action/custom/SendToSlack'
+                ] )
+                responseData['Data'] = securityhub.delete_action_target(ActionTargetArn=arnDeleteTo)
+              except Exception as e:
+                responseData['Data'] = str(e)
             cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, "CustomResourcePhysicalID") 
       MemorySize: 128
       Timeout: 10


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

DELETE_FAILED have been observed with event like shown below

>AddCustomActionSHResource1	DELETE_FAILED	Custom Resource failed to stabilize in expected time

CloudWatch logs:
>[ERROR] ResourceConflictException: An error occurred (ResourceConflictException) when calling the CreateActionTarget operation: Action with Id: SendToSlack already exists
> Traceback (most recent call last):
>   File "/var/task/index.py", line 5, in lambda_handler
>     response = securityhub.create_action_target(Name="Send_To_Slack",Description='Send Messages to ChatApplication via AWS ChatBot',Id='SendToSlack')
>   File "/var/runtime/botocore/client.py", line 316, in _api_call
>     return self._make_api_call(operation_name, kwargs)
>   File "/var/runtime/botocore/client.py", line 626, in _make_api_call
>     raise error_class(parsed_response, operation_name)

It seemes to attempt to create_action_target on every invocation no matter what RequestType is.
According to below,

https://stackoverflow.com/a/61006173
> also please note that Custom Resources are called when the stack is Created, Updated and Deleted. This can lead to some unexpected behaviour, especially during the Delete operation. It's normally a good idea to insert an if statement to only run the code during the Create phase by using:
> 
> if event['RequestType'] == 'Create':

Therefore requesting update to behave respectively

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
