### PR TITLE
Upgrade deprecated runtime nodejs12.x

### DIFF
--- a/SecurityHubFindingsToSlack.json
+++ b/SecurityHubFindingsToSlack.json
@@ -205,7 +205,7 @@
             "webHookUrl" : { "Ref": "IncomingWebHookURL" }
             }
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs16.x",
         "MemorySize" : 128,
                 "Timeout": 10,
         "Description" : "Lambda to push SecurityHub findings to Slack",


### PR DESCRIPTION
CloudFormation templates in aws-securityhub-to-slack have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs12.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.